### PR TITLE
Update all_example as a directory

### DIFF
--- a/ansible/dse_install.yml
+++ b/ansible/dse_install.yml
@@ -1,6 +1,13 @@
 ---
 
-# Exit process immediately if the Cassandra data directory exists on any node (don't want to overwrite a running system !)
+# Exit process immediately if the Cassandra keystores already exist on ansible host (don't want to overwrite a running system !)
+- hosts: localhost
+  any_errors_fatal: true
+  become: no
+  connection: local  
+  roles:
+  - { role: security_test_for_keystores }
+
 - hosts: dse
   any_errors_fatal: true
   become: true

--- a/ansible/group_vars/all_example/my.yml
+++ b/ansible/group_vars/all_example/my.yml
@@ -1,0 +1,4 @@
+# Include your overrrides here
+
+# my_ansible_user: ec2-user
+# etc,etc,etc

--- a/ansible/group_vars/all_example/vars.yml
+++ b/ansible/group_vars/all_example/vars.yml
@@ -7,7 +7,7 @@
 #   - default user for openstack/AWS: ubuntu
 #
 ansible_connection: ssh
-ansible_user: ubuntu                                                            #EDIT: Change from default e.g. ec2-user, ubuntu, automaton etc
+ansible_user: "{{ my_ansible_user | default('ubuntu') }}"                                                   #EDIT: Change from default e.g. ec2-user, ubuntu, automaton etc
 
 # DSE Superuser account
 #-------------------------------------------------------------------------------
@@ -15,8 +15,8 @@ ansible_user: ubuntu                                                            
 default_super_user_account: cassandra
 default_super_user_password: cassandra
 
-secure_super_user_account: TestAdmin                                            #EDIT: Change from default (TODO: pull from ansible.vault)
-secure_super_user_password: TestAdminPassword                                   #EDIT: Change from default (TODO: pull from ansible.vault)
+secure_super_user_account: "{{ my_secure_super_user_account | default('TestAdmin') }}"                      #EDIT: Change from default (Use ansible-vault)
+secure_super_user_password: "{{ my_secure_super_user_password | default('TestAdminPassword') }}"            #EDIT: Change from default (Use ansible-vault)
 
 # File permissions
 # Don't confuse cassandra OS account with cassandra internal superuser account
@@ -35,8 +35,8 @@ opscenter_group: opscenter
 dse_repo_file: /etc/apt/sources.list.d/datastax.sources.list
 
 #User name and password to download DSE (DataStax Academy)
-dse_repo_email: xxx                                                             #EDIT: Change from default (TODO: pull from ansible.vault)
-dse_repo_password: xxx                                                          #EDIT: Change from default (TODO: pull from ansible.vault)
+dse_repo_email: "{{ my_dse_repo_email | default('xxx') }}"                                                  #EDIT: Change from default (Use ansible-vault)
+dse_repo_password: "{{ my_dse_repo_password | default('xxx') }}"                                            #EDIT: Change from default (Use ansible-vault)
 
 # Target/Current DSE verson
 dse_major_version: 5.1                                                          #used to choose the correct configuration templates
@@ -60,24 +60,24 @@ vnode_token_num_spark: 32
 
 # data directories - need to modify these paths to reflect the mount point of 
 # your EBS drive/s OR ephemeral stores
-data_file_directories:  /var/lib/cassandra/data                                 #EDIT: Change from default
-hints_directory: /var/lib/cassandra/hints                                       #EDIT: Change from default
-commitlog_directory: /var/lib/cassandra/commitlog                               #EDIT: Change from default
-saved_caches_directory: /var/lib/cassandra/saved_caches                         #EDIT: Change from default
+data_file_directories:  "{{ my_data_file_directories | default('/var/lib/cassandra/data') }}"               #EDIT: Change from default
+hints_directory: "{{ my_hints_directory | default('/var/lib/cassandra/hints') }}"                           #EDIT: Change from default
+commitlog_directory: "{{ my_commitlog_directory | default('/var/lib/cassandra/commitlog') }}"               #EDIT: Change from default
+saved_caches_directory: "{{ my_saved_caches_directory | default('/var/lib/cassandra/saved_caches') }}"      #EDIT: Change from default
 
 # Storage settings
 #-------------------------------------------------------------------------------
 # consumed in role: dse_osparm_ssd_change
 
-is_ssd_storage: false                                                           #EDIT: Change to [true] if using ephemeral SSDs for DSE storage
+is_ssd_storage: "{{ my_is_ssd_storage | default(false) }}"                                                  #EDIT: Change to [true] if using ephemeral SSDs for DSE storage
 
 # Block device string for the attached EBS or ephemeral SSD volume for DSE data
-device_string: xxxx                                                             #EDIT: Change to /sys/block/<xxxx> for this SSD if using ephemeral SSDs for DSE storage 
+device_string: "{{ my_device_string | default('xxxx') }}"                                                   #EDIT: Change to /sys/block/<xxxx> for this SSD if using ephemeral SSDs for DSE storage 
 
 # Key Spark settings
 #-------------------------------------------------------------------------------
-dsefs_data_file_directory: /var/lib/dsefs/data                                  #EDIT: Change from default
-activate_alwaysonsql: false                                                     #EDIT: Requires DSE 6.0+
+dsefs_data_file_directory: "{{ my_dsefs_data_file_directory | default('/var/lib/dsefs/data') }}"            #EDIT: Change from default
+activate_alwaysonsql: "{{ my_activate_alwaysonsql | default(false) }}"                                      #EDIT: Requires DSE 6.0+
 
 # Cleanup of worker app data - Currently not used in any playbook (untested)
 spark_worker_cleanup_enabled: true
@@ -99,12 +99,12 @@ opsc_ssl_dir: /var/lib/opscenter/ssl
 
 opscenter_username: admin
 default_opscenter_password: admin
-secure_opscenter_password: opscenter_password_here                              #EDIT: Change from default (TODO: pull from ansible.vault)
+secure_opscenter_password: "{{ my_secure_opscenter_password | default('opscenter_password_here') }}"        #EDIT: Change from default (Use ansible-vault)
 
 # Key JMX settings
 #-------------------------------------------------------------------------------
-jmx_username: jmx_username                                                      #EDIT: Change from default (TODO: pull from ansible.vault)
-jmx_password: jmx_password                                                      #EDIT: Change from default (TODO: pull from ansible.vault)
+jmx_username: "{{ my_jmx_username | default('jmx_username') }}"                                             #EDIT: Change from default (Use ansible-vault)
+jmx_password: "{{ my_jmx_password | default('jmx_password') }}"                                             #EDIT: Change from default (Use ansible-vault)
 
 # path fix for JMX/JAAS/cassandra-env.sh
 jaas_path: "{{dse_config_dir}}/cassandra/cassandra-jaas.config"
@@ -115,8 +115,8 @@ jaas_path: "{{dse_config_dir}}/cassandra/cassandra-jaas.config"
 #TODO: 
 #dsecore/spark/graph should be 20G
 #solr should be 32GB (on larger nodes)
-heap_xms: 4G                                                                    #EDIT: Change from default
-heap_xmx: 4G                                                                    #EDIT: Change from default
+heap_xms: "{{ my_heap_xms | default('4G') }}"                                                               #EDIT: Change from default
+heap_xmx: "{{ my_heap_xmx | default('4G') }}"                                                               #EDIT: Change from default
 
 # Key role: security_dse_unified_authentication (info only):
 #-------------------------------------------------------------------------------
@@ -136,29 +136,29 @@ security_group: cassandra
 # Cluster security settings set by server_encryption_options 
 # and client_encryption_options in cassandra.yaml
 cluster_keystore_path: "{{ dse_config_dir }}/keystore.jks"
-cluster_keystore_password: cluster_keystore_password_here                       #EDIT: Change from default (TODO: pull from ansible.vault)
+cluster_keystore_password: "{{ my_cluster_keystore_password | default('cluster_keystore_password') }}"                  #EDIT: Change from default (Use ansible-vault)
 cluster_truststore_path: "{{ dse_config_dir }}/truststore.jks"
-cluster_truststore_password: "{{cluster_keystore_password}}"                    #EDIT: Change from default (TODO: pull from ansible.vault)
+cluster_truststore_password: "{{ my_cluster_truststore_password | default('cluster_keystore_password') }}"              #EDIT: Change from default (Use ansible-vault)
  
 # Root certificate
 #-------------------------------------------------------------------------------
 # The certs, .truststore and .keystores are created on the ansible 
 # controller node in the directory: ssl_certs_path
-is_self_signed_root_cert: true                                                  #EDIT: Change to [false] if CA certs
-etc_hosts_file_configure: false                                                 #EDIT: Change if CA certs AND no DNS server CN entries (CN name will be added to /etc/hosts)
+is_self_signed_root_cert: "{{ my_is_self_signed_root_cert | default(true) }}"                                           #EDIT: Change to [false] if CA certs
+etc_hosts_file_configure: "{{ my_etc_hosts_file_configure | default(false) }}"                                          #EDIT: Change if CA certs AND no DNS server CN entries (CN name will be added to /etc/hosts)
 
 # Not truely the CN, CN will be dynamically generated off each node's hostname.
-ssl_certs_common_name: "SelfSignRootCA"                                         #EDIT: Change from default if WILDCARD CA certs e.g [mysite.net]
+ssl_certs_common_name: "{{ my_ssl_certs_common_name | default('SelfSignRootCA') }}"                                     #EDIT: Change from default if WILDCARD CA certs e.g [mysite.net]
 
-ssl_cluster_name: "Test Cluster"        #OU                                     EDIT: Change from default if CA certs
-ssl_certs_organization: "Datastax"      #O                                      EDIT: Change from default if CA certs
-ssl_certs_country: "US"                 #C                                      EDIT: Change from default if CA certs
+ssl_cluster_name: "{{ my_ssl_cluster_name | default('Test Cluster') }}"             #OU                                 #EDIT: Change from default if CA certs
+ssl_certs_organization: "{{ my_ssl_certs_organization | default('Datastax') }}"     #O                                  #EDIT: Change from default if CA certs
+ssl_certs_country: "{{ my_ssl_certs_country | default('US') }}"                     #C                                  #EDIT: Change from default if CA certs
 
 # must be an account and group available on localhost
 ssl_certs_path_owner: "{{localhost_owner}}"
 ssl_certs_path_group: "{{localhost_group}}"
 
-ssl_certs_path: "/etc/ssl/{{ssl_certs_common_name}}"                            #EDIT: If CA certs MUST manually create this directory as [mysite.net] on ansible host first time and deploy your [mysite.net.pem] and [mysite.net.key] CA cert.
+ssl_certs_path: "/etc/ssl/{{ssl_certs_common_name}}"                            #NOTE: If CA certs MUST manually create this directory as [mysite.net] on ansible host first time and deploy your [mysite.net.pem] and [mysite.net.key] CA cert.
                                                                                 #ALSO: Change to your home directory if running ansible as a non-privileged user.
 ssl_certs_key_size: "2048"
 ssl_certs_days: "365"
@@ -175,7 +175,7 @@ ssl_certs_days: "365"
 #Actual audit logs are stored in: dse_syslog_dir/audit/audit.log
 #Log Storage location is controlled by: /etc/dse/cassandra/logback.xml section: [audit log]
 
-audit_logging_options_enabled: false                                            #EDIT: Change to [true] to activate
+audit_logging_options_enabled: "{{ my_audit_logging_options_enabled | default(false) }}"                                #EDIT: Change to [true] to activate
 audit_logging_options_logger: SLF4JAuditWriter
 audit_logging_options_included_categories: AUTH,DML,DDL,DCL
 
@@ -183,7 +183,7 @@ audit_logging_options_included_categories: AUTH,DML,DDL,DCL
 #-------------------------------------------------------------------------------
 # Can only run AFTER schema creation (need keyspace names for backup list)
 # For fine grain control directly edit /roles/opsc_services_configure/templates/
-is_automated_backup: false                                                      #EDIT: Change from false if backups required
-backup_path: /mnt/backups                                                       #EDIT: Should be located off node to be of any use
-backup_keyspace_list: keyspace1,keyspace2,keyspace3                             #EDIT: list keyspaces to backup, empty list means ALL keyspaces
+is_automated_backup: "{{ my_is_automated_backup | default(false) }}"                                                    #EDIT: Change from false if backups required
+backup_path: "{{ my_backup_path | default('/mnt/backups') }}"                                                           #EDIT: Should be located off node to be of any use
+backup_keyspace_list: "{{ my_backup_keyspace_list | default('keyspace1,keyspace2,keyspace3') }}"                        #EDIT: list keyspaces to backup, empty list means ALL keyspaces
 

--- a/ansible/group_vars/all_example/vars.yml
+++ b/ansible/group_vars/all_example/vars.yml
@@ -160,6 +160,7 @@ ssl_certs_path_group: "{{localhost_group}}"
 
 ssl_certs_path: "/etc/ssl/{{ssl_certs_common_name}}"                            #NOTE: If CA certs MUST manually create this directory as [mysite.net] on ansible host first time and deploy your [mysite.net.pem] and [mysite.net.key] CA cert.
                                                                                 #ALSO: Change to your home directory if running ansible as a non-privileged user.
+                                                                                #ALSO: The CA file MUST contain all its chain in strinct reverse order: Signing Intermediate CA first and Root CA last.
 ssl_certs_key_size: "2048"
 ssl_certs_days: "365"
 

--- a/ansible/group_vars/all_example/vault.yml
+++ b/ansible/group_vars/all_example/vault.yml
@@ -1,0 +1,7 @@
+# Include your overrrides here
+# You can use ansible-vault encrypt to protect this file
+
+
+# my_secure_super_user_account: TestAdmin
+# my_secure_super_user_password: TestAdminPassword
+# etc,etc,etc

--- a/ansible/roles/dse_updcfg/tasks/main.yml
+++ b/ansible/roles/dse_updcfg/tasks/main.yml
@@ -16,6 +16,14 @@
 
 #- debug: msg="{{ private_ip }}, {{ dc }}, {{ rack }}, {{ vnode }}, {{ vnode_token_num }}, {{ initial_token }}, {{ solr_enabled }}, {{ spark_enabled }}, {{ graph_enabled }}, {{ auto_bootstrap }}, {{ cluster_name }}, {{ data_file_directories }}, {{ commitlog_directory }}, {{ saved_caches_directory }}, {{ seeds }}"
 
+- name: Increase time init scripts wait for cassandra process to respond to something (iterations of 5 sec each)
+  lineinfile:
+    name: "{{ dse_default_dir }}/dse"
+    regexp: '^WAIT_FOR_START='
+    line: "WAIT_FOR_START=15"
+    owner: cassandra
+    group: cassandra
+    mode: 0644
 
 - name: Configure DSE Analytics workload type
   when: spark_enabled|int == 1

--- a/ansible/roles/security_create_keystores/tasks/main.yml
+++ b/ansible/roles/security_create_keystores/tasks/main.yml
@@ -17,46 +17,97 @@
 
 #Generate keystores for both [dse] and [opsc_dsecore] nodes
 
+
 - name: For each node, generate a keystore with key pair
-  command: keytool -genkeypair -keyalg RSA -alias "{{item}}" -keystore "{{ssl_certs_path}}/{{item}}-keystore.jks" -storepass "{{cluster_keystore_password}}" -keypass "{{cluster_keystore_password}}" -validity "{{ssl_certs_days}}" -keysize "{{ssl_certs_key_size}}" -dname "CN={{hostvars[item].private_dns if is_self_signed_root_cert | bool else 'ip-' + hostvars[item].private_ip.replace('.', '-') + '.' + ssl_certs_common_name }}, OU={{ssl_cluster_name}}, O={{ssl_certs_organization}}, C={{ssl_certs_country}}"
-  with_items: "{{ groups['dse']}}"
-- name: For each node, generate a keystore with key pair
-  command: keytool -genkeypair -keyalg RSA -alias "{{item}}" -keystore "{{ssl_certs_path}}/{{item}}-keystore.jks" -storepass "{{cluster_keystore_password}}" -keypass "{{cluster_keystore_password}}" -validity "{{ssl_certs_days}}" -keysize "{{ssl_certs_key_size}}" -dname "CN={{hostvars[item].private_dns if is_self_signed_root_cert | bool else 'ip-' + hostvars[item].private_ip.replace('.', '-') + '.' + ssl_certs_common_name }}, OU={{ssl_cluster_name}}, O={{ssl_certs_organization}}, C={{ssl_certs_country}}"
-  with_items: "{{ groups['opsc_dsecore']}}"
-  
-  
-- name: Generate a signing request from each keystore
-  command: keytool -alias "{{item}}" -keystore "{{ssl_certs_path}}/{{item}}-keystore.jks" -certreq -file "{{ssl_certs_path}}/{{item}}-signing_request.csr" -storepass "{{cluster_keystore_password}}" -keypass "{{cluster_keystore_password}}" -dname "CN={{hostvars[item].private_dns if is_self_signed_root_cert | bool else 'ip-' + hostvars[item].private_ip.replace('.', '-') + '.' + ssl_certs_common_name }}, OU={{ssl_cluster_name}}, O={{ssl_certs_organization}}, C={{ssl_certs_country}}"
-  with_items: "{{ groups['dse']}}"
-- name: Generate a signing request from each keystore
-  command: keytool -alias "{{item}}" -keystore "{{ssl_certs_path}}/{{item}}-keystore.jks" -certreq -file "{{ssl_certs_path}}/{{item}}-signing_request.csr" -storepass "{{cluster_keystore_password}}" -keypass "{{cluster_keystore_password}}" -dname "CN={{hostvars[item].private_dns if is_self_signed_root_cert | bool else 'ip-' + hostvars[item].private_ip.replace('.', '-') + '.' + ssl_certs_common_name }}, OU={{ssl_cluster_name}}, O={{ssl_certs_organization}}, C={{ssl_certs_country}}"
-  with_items: "{{ groups['opsc_dsecore']}}"
-  
-  
-- name: BYO sign each nodes certificate
-  command: openssl x509 -req -CA "{{ssl_certs_path}}/{{ssl_certs_common_name}}.pem" -CAkey "{{ssl_certs_path}}/{{ssl_certs_common_name}}.key" -in "{{ssl_certs_path}}/{{item}}-signing_request.csr" -out "{{ssl_certs_path}}/{{item}}.crt_signed" -days "{{ssl_certs_days}}" -CAcreateserial -passin pass:"{{cluster_keystore_password}}"
-  with_items: "{{ groups['dse']}}"
-- name: BYO sign each nodes certificate
-  command: openssl x509 -req -CA "{{ssl_certs_path}}/{{ssl_certs_common_name}}.pem" -CAkey "{{ssl_certs_path}}/{{ssl_certs_common_name}}.key" -in "{{ssl_certs_path}}/{{item}}-signing_request.csr" -out "{{ssl_certs_path}}/{{item}}.crt_signed" -days "{{ssl_certs_days}}" -CAcreateserial -passin pass:"{{cluster_keystore_password}}"
-  with_items: "{{ groups['opsc_dsecore']}}"
+  command: >
+    keytool -genkeypair -keyalg RSA -alias "{{item}}" -keystore "{{item}}-keystore.jks" 
+    -storepass "{{cluster_keystore_password}}" -keypass "{{cluster_keystore_password}}"
+    -validity "{{ssl_certs_days}}" -keysize "{{ssl_certs_key_size}}"
+    -dname "CN={{cn}}, OU={{ssl_cluster_name}}, O={{ssl_certs_organization}}, C={{ssl_certs_country}}"
+  args:
+    chdir: "{{ssl_certs_path}}"
+  vars:
+    cn: "{{hostvars[item].private_dns if is_self_signed_root_cert | bool else ansible_hostname + '.' + ssl_certs_common_name }}"
+  with_items:
+  - "{{ groups['dse']}}"
+  - "{{ groups['opsc_dsecore']}}"
+
+- block:
+  - name: Generate a signing request from each keystore
+    command: >
+      keytool -alias "{{item}}" -keystore "{{item}}-keystore.jks" -certreq -file "{{item}}-signing_request.csr" 
+      -storepass "{{cluster_keystore_password}}" -keypass "{{cluster_keystore_password}}"
+      -dname "CN={{cn}}, OU={{ssl_cluster_name}}, O={{ssl_certs_organization}}, C={{ssl_certs_country}}"
+    args:
+      chdir: "{{ssl_certs_path}}"
+    vars:
+      cn: "{{hostvars[item].private_dns if is_self_signed_root_cert | bool else ansible_hostname + '.' + ssl_certs_common_name }}"
+    with_items:
+    - "{{ groups['dse']}}"
+    - "{{ groups['opsc_dsecore']}}"
 
 
-- name: Import the root certificate into each node's keystore
-  command: keytool -keystore "{{ssl_certs_path}}/{{item}}-keystore.jks" -alias "{{ssl_certs_common_name}}" -importcert -file "{{ssl_certs_path}}/{{ssl_certs_common_name}}.pem" -noprompt  -storepass "{{cluster_keystore_password}}" -keypass "{{cluster_keystore_password}}"
-  with_items: "{{ groups['dse']}}"
-- name: Import the root certificate into each node's keystore
-  command: keytool -keystore "{{ssl_certs_path}}/{{item}}-keystore.jks" -alias "{{ssl_certs_common_name}}" -importcert -file "{{ssl_certs_path}}/{{ssl_certs_common_name}}.pem" -noprompt  -storepass "{{cluster_keystore_password}}" -keypass "{{cluster_keystore_password}}"
-  with_items: "{{ groups['opsc_dsecore']}}"
+  - name: BYO sign each nodes certificate
+    command: >
+      openssl x509 -req -CA "{{ssl_certs_common_name}}.pem" -CAkey "{{ssl_certs_common_name}}.key" 
+      -in "{{item}}-signing_request.csr" -out "{{item}}.crt_signed"
+      -days "{{ssl_certs_days}}" -CAcreateserial -passin pass:"{{cluster_keystore_password}}"
+    args:
+      chdir: "{{ssl_certs_path}}"
+    with_items:
+    - "{{ groups['dse']}}"
+    - "{{ groups['opsc_dsecore']}}"
 
+# SPLIT CA CERTIFICATE FILE
+- block:
+  - name: Split intermediates from root cert file
+    command: >
+      csplit --keep-files --elide-empty-files --prefix "{{ssl_certs_common_name}}-" 
+      "{{ssl_certs_common_name}}.pem" '/END CERTIFICATE/+1' {*}
+    args:
+      chdir: "{{ssl_certs_path}}"
 
-- name: Import the node's signed certificate into corresponding keystore
-  command: keytool -keystore "{{ssl_certs_path}}/{{item}}-keystore.jks" -alias "{{item}}" -importcert -noprompt -file "{{ssl_certs_path}}/{{item}}.crt_signed" -storepass "{{cluster_keystore_password}}" -keypass "{{cluster_keystore_password}}"
-  with_items: "{{ groups['dse']}}"
-- name: Import the node's signed certificate into corresponding keystore
-  command: keytool -keystore "{{ssl_certs_path}}/{{item}}-keystore.jks" -alias "{{item}}" -importcert -noprompt -file "{{ssl_certs_path}}/{{item}}.crt_signed" -storepass "{{cluster_keystore_password}}" -keypass "{{cluster_keystore_password}}"
-  with_items: "{{ groups['opsc_dsecore']}}"
-  
+  - name: "Find any empty split empty files"
+    lineinfile:
+      path: "{{item}}"
+      line: "-----END CERTIFICATE-----"
+      state: present
+    check_mode: yes
+    register: command_results
+    with_fileglob: "{{ lookup('fileglob', ssl_certs_path + '/'+ ssl_certs_common_name +'-*') }}"
+
+  - name: Delete any empty generated files
+    file:
+      path: "{{item.item}}"
+      state: absent
+    with_items: "{{ command_results.results }}"
+    when: item.changed
+
+- block:
+  - name: Import the root certificate into each node's keystore
+    command: >
+      keytool -keystore "{{host}}-keystore.jks" -alias "{{cert}}" -importcert -file "{{cert}}" -noprompt 
+      -storepass "{{cluster_keystore_password}}" -keypass "{{cluster_keystore_password}}"
+    args:
+      chdir: "{{ssl_certs_path}}"
+    vars:
+      host: "{{item[0]}}"
+      cert: "{{item[1]}}"
+    with_nested:
+    - "{{ groups['dse'] + groups['opsc_dsecore'] }}"
+    - "{{lookup('fileglob', ssl_certs_path + '/'+ ssl_certs_common_name +'-*').split(',') | sort |  reverse | list }}"
+
+  - name: Import the node's signed certificate into corresponding keystore
+    command: >
+      keytool -keystore "{{item}}-keystore.jks" -alias "{{item}}" 
+      -importcert -noprompt -file "{{item}}.crt_signed" 
+      -storepass "{{cluster_keystore_password}}" -keypass "{{cluster_keystore_password}}"
+    args:
+      chdir: "{{ssl_certs_path}}"    
+    with_items:
+    - "{{ groups['dse']}}"
+    - "{{ groups['opsc_dsecore']}}"
+
 #- name: Convert all the keystores into pkcs12 keystores
 #  command: keytool -importkeystore -srckeystore "{{ssl_certs_path}}/{{item}}-keystore.jks" -destkeystore "{{ssl_certs_path}}/{{item}}-pkcs12-keystore.jks" -deststoretype pkcs12 -storepass "{{cluster_keystore_password}}" -deststorepass "{{cluster_keystore_password}}"
 #  with_items: "{{ groups['dse'] }}"
-

--- a/ansible/roles/security_test_for_keystores/tasks/main.yml
+++ b/ansible/roles/security_test_for_keystores/tasks/main.yml
@@ -1,0 +1,13 @@
+
+
+# Determine if keystores have been created and bailout if they have
+  - name: "Exit process immediately if keystores are already present in the ansible host (don't want to overwrite a running system !)"
+    stat:
+      path: "{{ssl_certs_path}}/{{item}}-keystore.jks"
+    register: p
+    vars:
+      cn: "{{hostvars[item].private_dns if is_self_signed_root_cert | bool else ansible_hostname + '.' + ssl_certs_common_name }}"
+    with_items:
+    - "{{ groups['dse']}}"
+    - "{{ groups['opsc_dsecore']}}"
+    failed_when: p.stat.exists


### PR DESCRIPTION
Hi Alex, sending you the pull request with the following changes
1. use a new all_example directory to allow separation of your vars with custom user vars
2. Refactor custom CA certs tasks to sign and import all CAs into keystores
3. Allow a bit more time for the dse service to start up when restarting the service
4. Stop install if keystores are in the ansible host